### PR TITLE
Allow Cookie module to be imported from http package in python3

### DIFF
--- a/django_cookies_samesite/middleware.py
+++ b/django_cookies_samesite/middleware.py
@@ -1,4 +1,9 @@
-import Cookie
+# Cookie library has moved to http in python3
+try:
+    import Cookie
+except ImportError:
+    import https.cookies as Cookie
+
 import warnings
 
 import django


### PR DESCRIPTION
Cookie module no longer exists in python3 and has moved to the http package