### PR TITLE
Fixes #7 - Support 'None' Value

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Set your preferred SameSite policy in `settings.py`:
 
    SESSION_COOKIE_SAMESITE = 'Lax'
 
-This can be 'Lax', 'Strict', or None to disable the flag.
+This can be 'Lax', 'None', 'Strict', or None to disable the flag.
 
 Also, you can set this flag in your custom cookies:
 

--- a/django_cookies_samesite/middleware.py
+++ b/django_cookies_samesite/middleware.py
@@ -55,8 +55,8 @@ class CookiesSameSite(MiddlewareMixin):
         if not samesite_flag:
             return response
 
-        if samesite_flag.lower() not in {'lax', 'strict'}:
-            raise ValueError('samesite must be "lax" or "strict".')
+        if samesite_flag.lower() not in {'lax', 'none', 'strict'}:
+            raise ValueError('samesite must be "lax", "none", or "strict".')
 
         for cookie in protected_cookies:
             if cookie in response.cookies:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -37,6 +37,19 @@ class CookiesSamesiteTests(TestCase):
             self.assertTrue('sessionid=' in cookies_string[2])
             self.assertTrue('; SameSite=lax' in cookies_string[2])
 
+    def test_cookie_samesite_none(self):
+        with self.settings(SESSION_COOKIE_SAMESITE='none'):
+            response = self.client.get('/cookies-test/')
+
+            self.assertEqual(response.cookies['sessionid']['samesite'], 'none')
+            self.assertEqual(response.cookies['csrftoken']['samesite'], 'none')
+            cookies_string = sorted(response.cookies.output().split('\r\n'))
+
+            self.assertTrue('csrftoken=' in cookies_string[0])
+            self.assertTrue('; SameSite=none' in cookies_string[0])
+            self.assertTrue('sessionid=' in cookies_string[2])
+            self.assertTrue('; SameSite=none' in cookies_string[2])
+
     @unittest.skip('@TODO')
     def test_cookie_samesite_django21(self):
         # Raise DeprecationWarning for newer versions of Django
@@ -98,7 +111,7 @@ class CookiesSamesiteTests(TestCase):
             with self.assertRaises(ValueError) as exc:
                 self.client.get('/cookies-test/')
 
-            self.assertEqual(exc.exception.args[0], 'samesite must be "lax" or "strict".')
+            self.assertEqual(exc.exception.args[0], 'samesite must be "lax", "none", or "strict".')
 
     def test_cookie_samesite_unset(self):
         with self.settings(SESSION_COOKIE_SAMESITE=None):


### PR DESCRIPTION
Because of Google's aggressive timeline for Chrome 80 with this feature enabled planned for February 4th, 2020 it would be good to have support to explicitly set the value for SameSite to be 'none'

This fix just adds that as a supported string the same way as it is supported by the most recent version of Django. 

https://www.chromium.org/updates/same-site 