### PR TITLE
add SESSION_COOKIE_SAMESITE_FORCE_ALL flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+.venv

--- a/django_cookies_samesite/middleware.py
+++ b/django_cookies_samesite/middleware.py
@@ -58,8 +58,17 @@ class CookiesSameSite(MiddlewareMixin):
         if samesite_flag.lower() not in {'lax', 'none', 'strict'}:
             raise ValueError('samesite must be "lax", "none", or "strict".')
 
-        for cookie in protected_cookies:
-            if cookie in response.cookies:
+        samesite_force_all = getattr(
+            settings,
+            'SESSION_COOKIE_SAMESITE_FORCE_ALL',
+            False
+        )
+        if samesite_force_all:
+            for cookie in response.cookies:
                 response.cookies[cookie]['samesite'] = samesite_flag.lower()
+        else:
+            for cookie in protected_cookies:
+                if cookie in response.cookies:
+                    response.cookies[cookie]['samesite'] = samesite_flag.lower()
 
         return response

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ universal = 1
 
 [flake8]
 ignore = D203
-exclude = 
+exclude =
 	django_cookies_samesite/migrations,
 	.git,
 	.tox,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -50,6 +50,25 @@ class CookiesSamesiteTests(TestCase):
             self.assertTrue('sessionid=' in cookies_string[2])
             self.assertTrue('; SameSite=none' in cookies_string[2])
 
+        with self.settings(SESSION_COOKIE_SAMESITE='none', SESSION_COOKIE_SAMESITE_FORCE_ALL=True):
+            response = self.client.get('/cookies-test/')
+
+            self.assertEqual(response.cookies['sessionid']['samesite'], 'none')
+            self.assertEqual(response.cookies['csrftoken']['samesite'], 'none')
+            self.assertEqual(response.cookies['custom_cookie']['samesite'], 'none')
+            self.assertEqual(response.cookies['zcustom_cookie']['samesite'], 'none')
+
+            cookies_string = sorted(response.cookies.output().split('\r\n'))
+
+            self.assertTrue('custom_cookie=' in cookies_string[1])
+            self.assertTrue('; SameSite=none' in cookies_string[1])
+            self.assertTrue('csrftoken=' in cookies_string[0])
+            self.assertTrue('; SameSite=none' in cookies_string[0])
+            self.assertTrue('sessionid=' in cookies_string[2])
+            self.assertTrue('; SameSite=none' in cookies_string[2])
+            self.assertTrue('zcustom_cookie=' in cookies_string[3])
+            self.assertTrue('; SameSite=none' in cookies_string[3])
+
     @unittest.skip('@TODO')
     def test_cookie_samesite_django21(self):
         # Raise DeprecationWarning for newer versions of Django


### PR DESCRIPTION
For some cases, we need to set "samesite" in all cookies. Especially useful when we don't know cookie names that third party package created.