### PR TITLE
Added ability to check and update SameSite policy, with this changes SameSite policy will not be updated for the incompatible clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+  - pip install -r requirements.txt
   - pip install -r requirements_dev.txt
   - pip install -r requirements_test.txt
 

--- a/django_cookies_samesite/middleware.py
+++ b/django_cookies_samesite/middleware.py
@@ -4,9 +4,6 @@ try:
 except ImportError:
     import http.cookies as Cookie
 
-import re
-
-
 import django
 
 from distutils.version import LooseVersion
@@ -18,9 +15,9 @@ try:
 except ImportError:
     MiddlewareMixin = object
 
+from django_cookies_samesite.user_agent_checker import UserAgentChecker
 
 Cookie.Morsel._reserved['samesite'] = 'SameSite'
-CHROME_VALIDATE_REGEX = re.compile(r"(Chrome|Chromium)\/((5[1-9])|6[0-6])")
 
 # TODO: change this to 3.1.0 once Django 3.1 is released
 DJANGO_SUPPORTED_VERSION = '3.0.0'
@@ -61,8 +58,9 @@ class CookiesSameSite(MiddlewareMixin):
         # same-site = None introduced for Chrome 80 breaks for Chrome 51-66
         # Refer (https://www.chromium.org/updates/same-site/incompatible-clients)
         http_user_agent = request.META.get('HTTP_USER_AGENT') or " "
+        user_agent_checker = UserAgentChecker(http_user_agent)
 
-        if re.search(CHROME_VALIDATE_REGEX, http_user_agent):
+        if user_agent_checker.do_not_send_same_site_policy:
             return response
 
         if LooseVersion(django.get_version()) >= LooseVersion(DJANGO_SUPPORTED_VERSION):

--- a/django_cookies_samesite/user_agent_checker.py
+++ b/django_cookies_samesite/user_agent_checker.py
@@ -1,0 +1,97 @@
+from ua_parser import user_agent_parser
+import re
+
+
+class UserAgentChecker:
+    UC_BROWSER = 'UC Browser'
+    SAFARI_REGX = 'Safari'
+    CHROME_REGX = 'Chrom(e|ium)'
+    MAC_OSX = 'Mac OS X'
+    IOS = 'iOS'
+    MIN_UC_BROWSER_VER_MAJOR = 12
+    MIN_UC_BROWSER_VER_MINOR = 13
+    MIN_UC_BROWSER_VER_BUILD = 2
+    BUGGY_CHROME_VERSION_MAJOR_MIN = 51
+    BUGGY_CHROME_VERSION_MAJOR_MAX = 66
+    MIN_IOS_VERSION = 12
+    MIN_MAC_OSX_VERSION_MAJOR = 10
+    MIN_MAC_OSX_VERSION_MINOR = 14
+
+    def __init__(self, user_agent_string=''):
+        user_agent_parsed = user_agent_parser.Parse(user_agent_string if user_agent_string else '')
+        self.user_agent = user_agent_parsed.get('user_agent', dict())
+        self.user_agent_os = user_agent_parsed.get('os', dict())
+        self.user_agent_device = user_agent_parsed.get('device', dict())
+        self.user_agent_string = user_agent_parsed.get('string', '')
+
+    @property
+    def do_not_send_same_site_policy(self):
+        if not self.user_agent_string:
+            return False
+        else:
+            return not (self.supported_browsers_os() or self.other_browsers())
+
+    def supported_browsers_os(self):
+        return self.supported_ios_and_mac_os_browsers() or self.supported_chrome_and_uc_browsers()
+
+    def supported_chrome_and_uc_browsers(self):
+        return self.is_chrome_supported_version() or self.is_uc_browser_in_least_supported_version()
+
+    def supported_ios_and_mac_os_browsers(self):
+        return self.is_supported_ios_version() or self.is_supported_mac_osx_safari()
+
+    def other_browsers(self):
+        is_uc_or_chrome = self.is_uc_browser() or self.is_chrome_browser()
+        is_safari_ios_mac_supported = self.is_safari() or self.is_ios() or self.is_supported_mac_osx_safari()
+        return not (is_uc_or_chrome or is_safari_ios_mac_supported)
+
+    def is_uc_browser(self):
+        return self.user_agent.get('family') == 'UC Browser'
+
+    def is_uc_browser_in_least_supported_version(self):
+        major = int(self.user_agent.get('major', '0') if self.user_agent.get('major') else '0')
+        minor = int(self.user_agent.get('minor', '0') if self.user_agent.get('minor') else '0')
+        build = int(self.user_agent.get('patch', '0') if self.user_agent.get('patch') else '0')
+        if self.is_uc_browser():
+            if self.MIN_UC_BROWSER_VER_MAJOR == major:
+                if self.MIN_UC_BROWSER_VER_MINOR == minor:
+                    return self.MIN_UC_BROWSER_VER_BUILD <= build
+                else:
+                    return self.MIN_UC_BROWSER_VER_MINOR < minor
+            else:
+                return self.MIN_UC_BROWSER_VER_MAJOR < major
+        return False
+
+    def is_chrome_browser(self):
+        return True if re.search(self.CHROME_REGX, self.user_agent.get('family', '')) else False
+
+    def is_chrome_supported_version(self):
+        uav = int(self.user_agent.get('major', '0') if self.user_agent.get('major') else '0')
+        return True if self.is_chrome_browser() and (
+            self.BUGGY_CHROME_VERSION_MAJOR_MIN > uav or uav > self.BUGGY_CHROME_VERSION_MAJOR_MAX) else False
+
+    def is_supported_chrome(self):
+        return self.is_chrome_supported_version()
+
+    def is_ios(self):
+        return self.user_agent_os.get('family') == self.IOS
+
+    def is_supported_ios_version(self):
+        return self.is_ios() and not (int(self.user_agent_os.get('major', '0')) == self.MIN_IOS_VERSION)
+
+    def is_mac_osx(self):
+        return self.user_agent_os.get('family', '') == self.MAC_OSX
+
+    def is_supported_mac_osx_version(self):
+        if self.is_mac_osx():
+            is_min_mac_maj = (int(self.user_agent_os.get('major', '0')) == self.MIN_MAC_OSX_VERSION_MAJOR)
+            is_min_mac_min = (int(self.user_agent_os.get('minor', '0')) == self.MIN_MAC_OSX_VERSION_MINOR)
+            return not (is_min_mac_maj and is_min_mac_min)
+        return False
+
+    def is_safari(self):
+        is_safari_reg_res = re.search(self.SAFARI_REGX, self.user_agent.get('family', ''))
+        return True if is_safari_reg_res and not self.is_chrome_browser() else False
+
+    def is_supported_mac_osx_safari(self):
+        return self.is_supported_mac_osx_version() and self.is_safari()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-
 # Additional requirements go here
+ua-parser==0.10.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,2 @@
 bumpversion==0.5.3
 wheel==0.30.0
-

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -48,9 +48,11 @@ class CookieSamesiteConfigTests(TestCase):
 @ddt
 class CookiesSamesiteTestsWithConfigPrefix(TestCase):
     config_prefix = "DCS_"
+
     @contextmanager
     def settings(self, **config_settings):
         """Override all settings with the prefix name"""
+
         def format_key(k):
             """Prefix only the middleware settings."""
             return "{}{}".format(self.config_prefix, k) if k.startswith("SESSION_COOKIE_SAMESITE") else k
@@ -247,13 +249,15 @@ class CookiesSamesiteTestsWithConfigPrefix(TestCase):
 
     @data(
         # Chrome
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.2704.103 Safari/537.36",
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.2704.103 Safari/537.36',
         # Firefox
         "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0",
         # Internet Explorer
         "Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)",
         # Safari
-        "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1" # noqa
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) '
+        'Version/10.0 Mobile/14E304 Safari/602.1 '
+        # noqa
     )
     @unittest.skipIf(django.get_version() >= DJANGO_SUPPORTED_VERSION, 'should skip if Django already supports')
     def test_supported_browsers(self, ua_string):

--- a/tests/test_user_agent_checker.py
+++ b/tests/test_user_agent_checker.py
@@ -1,0 +1,149 @@
+import unittest
+from django_cookies_samesite.user_agent_checker import UserAgentChecker
+
+
+class TestUserAgentChecker(unittest.TestCase):
+
+    # On init UserAgentChecker class user agent should be parsed ready.
+    def test_user_agent_parser_available(self):
+        user_agent_checker = UserAgentChecker(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3334.0 "
+            "Safari/537.36")
+        self.assertEqual(user_agent_checker.__class__.__name__, "UserAgentChecker")
+        self.assertEqual(user_agent_checker.user_agent['family'], 'Chrome')
+        self.assertEqual(user_agent_checker.user_agent_os['family'], 'Windows')
+        self.assertEqual(user_agent_checker.user_agent_string, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                                                               'AppleWebKit/537.36 (KHTML, like Gecko) '
+                                                               'Chrome/66.0.3334.0 Safari/537.36')
+
+    # Function do_not_send_same_site returns true if user agent is null or blank.
+    def test_should_return_false_if_user_agent_is_empty(self):
+        user_agent_checker = UserAgentChecker()
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+        user_agent_checker = UserAgentChecker(None)
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+    def test_should_return_false_only_for_supported_browsers(self):
+        # Should return True for unsupported iOS
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/ "
+                                              "604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a "
+                                              "Safari/602.1.26")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, True)
+
+        # Should return True for unsupported MAC OS X 10.14 safari browser
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 ("
+                                              "KHTML, like Gecko) Version/12.0 Safari/605.1.15")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, True)
+
+        # Should return False for supported MAC OS X 10.14 non safari browser
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 ("
+                                              "KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return False for supported MAC OS X 10.6 safari browser
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; en-en) "
+                                              "AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return True for unsupported chrome browser version 51 to 66
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+                                              "like Gecko) Chrome/66.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, True)
+
+        # Should return False for supported chrome browser version > 66
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+                                              "like Gecko) Chrome/67.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return False for supported chrome browser version < 51
+        user_agent_checker = UserAgentChecker("Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                                              "Chrome/50.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return True for unsupported UC browsers under 12.13.2
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/11.5.1.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, True)
+
+        # Should return True for unsupported UC browsers under 12.13.2
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/12.12.3.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, True)
+
+        # Should return True for unsupported UC browsers under 12.13.2
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/12.13.1.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, True)
+
+        # Should return False for supported UC browsers >= 12.13.2
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/12.13.2.1 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return False for Other Browsers
+        user_agent_checker = UserAgentChecker("Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.18")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return False for Other Browsers
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:64.0) Gecko/20100101 "
+                                              "Firefox/64.0")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+        # Should return False for Other Browsers
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) "
+                                              "like Gecko")
+        self.assertEqual(user_agent_checker.do_not_send_same_site_policy, False)
+
+    def test_is_chrome_supported_version(self):
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+                                              "like Gecko) Chrome/67.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.is_chrome_supported_version(), True)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+                                              "like Gecko) Chrome/66.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.is_chrome_supported_version(), False)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+                                              "like Gecko) Chrome/50.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.is_chrome_supported_version(), True)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, "
+                                              "like Gecko) Chrome/51.0.3334.0 Safari/537.36")
+        self.assertEqual(user_agent_checker.is_chrome_supported_version(), False)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36(KHTML, like Gecko) "
+                                              "Ubuntu Chromium/69.0.3497.8 Chrome/69.0.81 Safari/537.36")
+        self.assertEqual(user_agent_checker.is_chrome_supported_version(), True)
+
+    def test_is_uc_browser_in_least_supported_version(self):
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/13.5.1.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), True)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/11.5.1.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), False)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/12.13.2.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), True)
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) "
+                                              "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 "
+                                              "UCBrowser/12.13.1.944 Mobile Safari/537.36")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), False)
+
+    def test_is_unsupported_ios_version(self):
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/ "
+                                              "604.1.21 (KHTML, like Gecko) Version/ 12.0 Mobile/17A6278a "
+                                              "Safari/602.1.26")
+        self.assertEqual(user_agent_checker.is_supported_ios_version(), False)
+
+    def test_is_unsupported_mac_osx_version(self):
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 ("
+                                              "KHTML, like Gecko) Version/12.0 Safari/605.1.15")
+        self.assertEqual(user_agent_checker.is_supported_mac_osx_safari(), False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     django-111: Django>=1.11,<1.12
     django-20: Django>=2.0,<2.1
     django-30: Django>=3.0
+    -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt
 basepython =
     py27: python2.7


### PR DESCRIPTION
Chrome provided the incompatible clients for SameSite policy. 
Here https://www.chromium.org/updates/same-site/incompatible-clients

Currently, we are only checking for the Chrome versions between 51 to 66. This PR includes the check for incompatible clients.