### PR TITLE
Fix the setup of requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include README.rst
+include requirements*.txt
 recursive-include django_cookies_samesite *.html *.png *.gif *js *.css *jpg *jpeg *svg *py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from io import open
 import os
 import re
 import sys
@@ -23,6 +24,31 @@ def get_version(*file_paths):
 
 version = get_version("django_cookies_samesite", "__init__.py")
 
+def load_requirements(*requirements_paths):
+    """
+    Load all requirements from the specified requirements files.
+
+    Returns:
+        list: Requirements file relative path strings
+    """
+    requirements = set()
+    for path in requirements_paths:
+        with open(path) as reqs:
+            requirements.update(
+                line.split('#')[0].strip() for line in reqs
+                if is_requirement(line.strip())
+            )
+    return list(requirements)
+
+
+def is_requirement(line):
+    """
+    Return True if the requirement line is a package requirement.
+
+    Returns:
+        bool: True if the line is not blank, a comment, a URL, or an included file
+    """
+    return line and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 if sys.argv[-1] == 'publish':
     try:
@@ -55,7 +81,8 @@ setup(
         'django_cookies_samesite',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=load_requirements('requirements.txt'),
+    tests_require=load_requirements('requirements_test.txt'),
     zip_safe=False,
     keywords='django-cookies-samesite',
     classifiers=[


### PR DESCRIPTION
The current list of dependencies is defined in `requirements.txt` and Setuptools is not able to read those files. @timmc-edx made a nice hack to fix this problem.