### PR TITLE
Exception when UA patch isn't a number

### DIFF
--- a/django_cookies_samesite/user_agent_checker.py
+++ b/django_cookies_samesite/user_agent_checker.py
@@ -61,7 +61,10 @@ class UserAgentChecker:
     def is_uc_browser_in_least_supported_version(self):
         major = int(self.user_agent.get("major") or "0")
         minor = int(self.user_agent.get("minor") or "0")
-        build = int(self.user_agent.get("patch") or "0")
+        try:
+            build = int(self.user_agent.get("patch") or "0")
+        except ValueError:
+            build = 0
         if self.is_uc_browser():
             if self.MIN_UC_BROWSER_VER_MAJOR == major:
                 if self.MIN_UC_BROWSER_VER_MINOR == minor:

--- a/django_cookies_samesite/user_agent_checker.py
+++ b/django_cookies_samesite/user_agent_checker.py
@@ -27,6 +27,17 @@ class UserAgentChecker:
         self.user_agent_string = user_agent_parsed.get("string", "")
 
     @property
+    def user_agent_version_parts(self):
+        version_parts = []
+        for name in ["major", "minor", "patch"]:
+            try:
+                num_part = int(self.user_agent.get(name))
+            except (TypeError, ValueError):
+                num_part = 0
+            version_parts.append(num_part)
+        return version_parts
+
+    @property
     def do_not_send_same_site_policy(self):
         if not self.user_agent_string:
             return False
@@ -59,12 +70,7 @@ class UserAgentChecker:
         return self.user_agent.get("family") == "UC Browser"
 
     def is_uc_browser_in_least_supported_version(self):
-        major = int(self.user_agent.get("major") or "0")
-        minor = int(self.user_agent.get("minor") or "0")
-        try:
-            build = int(self.user_agent.get("patch") or "0")
-        except ValueError:
-            build = 0
+        major, minor, build = self.user_agent_version_parts
         if self.is_uc_browser():
             if self.MIN_UC_BROWSER_VER_MAJOR == major:
                 if self.MIN_UC_BROWSER_VER_MINOR == minor:
@@ -83,7 +89,7 @@ class UserAgentChecker:
         )
 
     def is_chrome_supported_version(self):
-        uav = int(self.user_agent.get("major") or "0")
+        uav, _, _ = self.user_agent_version_parts
         return (
             True
             if self.is_chrome_browser()

--- a/tests/test_user_agent_checker.py
+++ b/tests/test_user_agent_checker.py
@@ -148,8 +148,17 @@ class TestUserAgentChecker(unittest.TestCase):
                                               "KHTML, like Gecko) Version/12.0 Safari/605.1.15")
         self.assertEqual(user_agent_checker.is_supported_mac_osx_safari(), False)
 
-    def test_firefox_alpha(self):
+    def test_non_numeric_versions(self):
+        # Patch version is not a numeric 'a2'
         user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), False)
+
+        # Minor & patch versions are not numeric 'x'
+        user_agent_checker = UserAgentChecker("Liferea/0.x.x (Linux; en_US.UTF-8; http://liferea.sf.net/)")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), False)
+
+        # All version parts are not numeric
+        user_agent_checker = UserAgentChecker("Liferea/x.x.x (Linux; en_US.UTF-8; http://liferea.sf.net/)")
         self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), False)
 
 

--- a/tests/test_user_agent_checker.py
+++ b/tests/test_user_agent_checker.py
@@ -148,6 +148,10 @@ class TestUserAgentChecker(unittest.TestCase):
                                               "KHTML, like Gecko) Version/12.0 Safari/605.1.15")
         self.assertEqual(user_agent_checker.is_supported_mac_osx_safari(), False)
 
+    def test_firefox_alpha(self):
+        user_agent_checker = UserAgentChecker("Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2")
+        self.assertEqual(user_agent_checker.is_uc_browser_in_least_supported_version(), False)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We've added this package to our site recently and started receiving some errors today: `ValueError
invalid literal for int() with base 10: 'a2'`.

The traceback leads to this line:

https://github.com/jotes/django-cookies-samesite/blob/d3a726be9f8b233118c4516990d37c52667e1653/django_cookies_samesite/user_agent_checker.py#L64

Basically, someone browsing our site with a very old Alpha version of Firefox from 2012. We don't have many errors, but would be nice to handle this a bit better.