### PR TITLE
Add a blank line to fix the rendering of a code block.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Add the middleware to the top of `MIDDLEWARE_CLASSES`:
 
 
 Set your preferred SameSite policy in `settings.py`:
+
 .. code-block:: python
 
    SESSION_COOKIE_SAMESITE = 'lax'
@@ -101,4 +102,3 @@ Contributors
 * Liuyang Wan <noreply@github.com>
 * Mykolas Kvieska <noreply@github.com>
 * Tim McCormack <tmccormack@edx.org>
-


### PR DESCRIPTION
It currently  looks like this on PyPI:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/23789/95908290-dcfa0780-0d6a-11eb-846e-5016a6c229fc.png">
