### PR TITLE
Add an optional setting to disable core cookies handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,14 @@ You can set the SameSite flag on all cookies (even on those coming from third-pa
     # or
     DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 
+The `sessionid` and `csrftoken` cookies are automatically handled by the middleware. This behavior can be disabled with:
+
+.. code-block:: python
+
+   SESSION_COOKIE_SAMESITE_FORCE_CORE = False
+   # or
+   DCS_SESSION_COOKIE_SAMESITE_FORCE_CORE = False
+
 Running Tests
 -------------
 

--- a/django_cookies_samesite/middleware.py
+++ b/django_cookies_samesite/middleware.py
@@ -51,10 +51,11 @@ class CookiesSameSite(MiddlewareMixin):
             )
 
         self.protected_cookies = set(self.protected_cookies)
-        self.protected_cookies |= {
-            settings.SESSION_COOKIE_NAME,
-            settings.CSRF_COOKIE_NAME,
-        }
+        if get_config_setting("SESSION_COOKIE_SAMESITE_FORCE_CORE", True):
+            self.protected_cookies |= {
+                settings.SESSION_COOKIE_NAME,
+                settings.CSRF_COOKIE_NAME,
+            }
 
         samesite_flag = get_config_setting("SESSION_COOKIE_SAMESITE", "")
         self.samesite_flag = (

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -44,7 +44,7 @@ class CookieSamesiteConfigTests(TestCase):
             self.assertEqual(middleware.samesite_flag, 'Lax')
             self.assertEqual(middleware.samesite_force_all, True)
             self.assertEqual(middleware.protected_cookies, {'sessionid', 'csrftoken', 'custom_cookie'})
-    
+
         with(self.settings(**{
             "{}SESSION_COOKIE_SAMESITE_FORCE_CORE".format(config_prefix): False,
             "{}SESSION_COOKIE_SAMESITE_KEYS".format(config_prefix): {'custom_cookie'},

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -44,6 +44,13 @@ class CookieSamesiteConfigTests(TestCase):
             self.assertEqual(middleware.samesite_flag, 'Lax')
             self.assertEqual(middleware.samesite_force_all, True)
             self.assertEqual(middleware.protected_cookies, {'sessionid', 'csrftoken', 'custom_cookie'})
+    
+        with(self.settings(**{
+            "{}SESSION_COOKIE_SAMESITE_FORCE_CORE".format(config_prefix): False,
+            "{}SESSION_COOKIE_SAMESITE_KEYS".format(config_prefix): {'custom_cookie'},
+        })):
+            middleware = CookiesSameSite()
+            self.assertEqual(middleware.protected_cookies, {'custom_cookie'})
 
 
 @ddt


### PR DESCRIPTION
On some case, one might want only one of the cookie to be setup by CDS. This setting allows for both the `SESSION_COOKIE_NAME` and `CSRF_COOKIE_NAME` cookies not to be handled.